### PR TITLE
Add workflow to build and deploy app to github pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: cgol-rust-pkg
+          path: ./cgol-rust/pkg
       - name: Install dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,27 @@ jobs:
       - name: Build
         run: npm run build
       - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: ./cgol-web/dist
+
+  upload-gh-pages:
+    runs-on: ubuntu-latest
+    needs: [build-cgol-web]
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: cgol-rust-pkg
+          path: ./cgol-web/dist
+      - name: Upload for GitHub Pages
         id: deployment
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./cgol-web/dist
 
-  deploy:
+  deploy-gh-pages:
     runs-on: ubuntu-latest
     needs: [build-cgol-web]
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build
-        run: npm run build
+        run: npm run build -- --base-href /${GITHUB_REPOSITORY#*/}
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: ci
+
+on: push
+
+jobs:
+  build-cgol-rust:
+    runs-on: ubuntu-latest
+    container: rust:1-slim-trixie
+    defaults:
+      run:
+        working-directory: ./cgol-rust
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install wasm-pack
+        run: cargo install wasm-pack
+      - name: Build
+        run: wasm-pack build --target bundler --out-dir pkg
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: cgol-rust-pkg
+          path: ./cgol-rust/pkg
+
+  test-cgol-rust:
+    runs-on: ubuntu-latest
+    container: rust:1-slim-trixie
+    defaults:
+      run:
+        working-directory: ./cgol-rust
+    steps:
+      - uses: actions/checkout@v5
+      - name: Run tests
+        run: cargo test
+
+  build-cgol-web:
+    runs-on: ubuntu-latest
+    container: node:22-alpine
+    needs: [build-cgol-rust]
+    defaults:
+      run:
+        working-directory: ./cgol-web
+    steps:
+      - uses: actions/checkout@v5
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: cgol-rust-pkg
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: ./cgol-web/dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build
-        run: npm run build
+        run: ng build --configuration production
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        id: deployment
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: dist
           path: ./cgol-web/dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [build-cgol-web]
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v5
         with:
-          name: cgol-rust-pkg
+          name: dist
           path: ./cgol-web/dist
       - name: Upload for GitHub Pages
         id: deployment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         id: deployment
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./cgol-web/dist
+          path: ./cgol-web/dist/cgol-web/browser
 
   deploy-gh-pages:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build
-        run: npm run build -- --base-href /${GITHUB_REPOSITORY#*/}
+        run: npm run build -- --base-href .
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build
-        run: ng build --configuration production
+        run: npm run build
       - name: Upload artifact
         id: deployment
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
 
   deploy-gh-pages:
     runs-on: ubuntu-latest
-    needs: [build-cgol-web]
+    needs: [upload-gh-pages]
     permissions:
       pages: write
       id-token: write

--- a/cgol-web/package.json
+++ b/cgol-web/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "build": "ng build --base-href /angular-wasm-tutorial/",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"
   },

--- a/cgol-web/package.json
+++ b/cgol-web/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --base-href /angular-wasm-tutorial/",
+    "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"
   },


### PR DESCRIPTION
# Overview
Added the `.github/workflows/ci.yml` file, which defines a workflow to build and deploy the app to github pages. 

There was a hitch with deploying directly from the `build-cgol-web` job - the [`upload-pages-artifact`](https://github.com/actions/upload-pages-artifact) job doesn't seem to work in the alpine-based container. Therefore there is a separate job `upload-gh-pages` to download the build and reupload it as a pages artifact.

# Test Procedure
1. Check out https://davidzhhdwys4.github.io/CGOL/